### PR TITLE
PoC: Native minting loss subsidization 

### DIFF
--- a/contracts/EtherfiL1SyncPoolETH.sol
+++ b/contracts/EtherfiL1SyncPoolETH.sol
@@ -231,7 +231,8 @@ contract EtherfiL1SyncPoolETH is L1BaseSyncPoolUpgradeable {
         // socialize native minting losses with the protocol
         if (actualAmountOut < amountOut) {
 
-            if (actualAmountOut < (amountOut * 9995) / 10000) {
+            // if the minting loss is higher than 50 bps, revert
+            if (actualAmountOut < (amountOut * 995) / 1000) {
                 revert("EtherfiL1SyncPoolETH: minting loss too high");
             }
 

--- a/contracts/EtherfiL1SyncPoolETH.sol
+++ b/contracts/EtherfiL1SyncPoolETH.sol
@@ -235,7 +235,7 @@ contract EtherfiL1SyncPoolETH is L1BaseSyncPoolUpgradeable {
             actualAmountOut = amountOut;
         }
 
-        _handleAnticipatedDeposit(origin.srcEid, guid, actualAmountOut, amountOut);
+        _handleAnticipatdeDeposit(origin.srcEid, guid, actualAmountOut, amountOut);
     }
 
 }

--- a/contracts/EtherfiL1SyncPoolETH.sol
+++ b/contracts/EtherfiL1SyncPoolETH.sol
@@ -230,6 +230,11 @@ contract EtherfiL1SyncPoolETH is L1BaseSyncPoolUpgradeable {
 
         // socialize native minting losses with the protocol
         if (actualAmountOut < amountOut) {
+
+            if (actualAmountOut < (amountOut * 9995) / 10000) {
+                revert("EtherfiL1SyncPoolETH: minting loss too high");
+            }
+
             IERC20 tokenOut = IERC20(getTokenOut());
             uint256 balanceBefore = tokenOut.balanceOf(address(this));
 

--- a/contracts/EtherfiL1SyncPoolETH.sol
+++ b/contracts/EtherfiL1SyncPoolETH.sol
@@ -235,7 +235,7 @@ contract EtherfiL1SyncPoolETH is L1BaseSyncPoolUpgradeable {
             actualAmountOut = amountOut;
         }
 
-        _handleAnticipatdeDeposit(origin.srcEid, guid, actualAmountOut, amountOut);
+        _handleAnticipatedDeposit(origin.srcEid, guid, actualAmountOut, amountOut);
     }
 
 }

--- a/contracts/EtherfiL1SyncPoolETH.sol
+++ b/contracts/EtherfiL1SyncPoolETH.sol
@@ -231,7 +231,7 @@ contract EtherfiL1SyncPoolETH is L1BaseSyncPoolUpgradeable {
         // socialize native minting losses with the protocol
         if (actualAmountOut < amountOut) {
             uint256 unbackedAmount = amountOut - actualAmountOut;
-            liquidityPool.depositToRecipient(unbackedAmount);
+            liquidityPool.depositToSyncPool(unbackedAmount);
             actualAmountOut = amountOut;
         }
 

--- a/contracts/L1BaseSyncPoolUpgradeable.sol
+++ b/contracts/L1BaseSyncPoolUpgradeable.sol
@@ -199,24 +199,6 @@ abstract contract L1BaseSyncPoolUpgradeable is OAppReceiverUpgradeable, Reentran
     }
 
     /**
-     * @dev Internal function called when a LZ message is received
-     * @param origin Origin
-     * @param guid Message GUID
-     * @param message Message
-     */
-    function _lzReceive(Origin calldata origin, bytes32 guid, bytes calldata message, address, bytes calldata)
-        internal
-        virtual
-        override
-    {
-        (address tokenIn, uint256 amountIn, uint256 amountOut) = abi.decode(message, (address, uint256, uint256));
-
-        uint256 actualAmountOut = _anticipatedDeposit(origin.srcEid, guid, tokenIn, amountIn, amountOut);
-
-        _handleAnticipatedDeposit(origin.srcEid, guid, actualAmountOut, amountOut);
-    }
-
-    /**
      * @dev Internal function to set the main token address
      * @param tokenOut Address of the main token
      */

--- a/interfaces/ILiquidityPool.sol
+++ b/interfaces/ILiquidityPool.sol
@@ -3,5 +3,5 @@
 pragma solidity ^0.8.20;
 
 interface ILiquidityPool {
-    function depositToRecipient(uint256 _amount) external returns (uint256);
+    function depositToSyncPool(uint256 _amount) external returns (uint256);
 }

--- a/interfaces/ILiquidityPool.sol
+++ b/interfaces/ILiquidityPool.sol
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 

--- a/interfaces/ILiquidityPool.sol
+++ b/interfaces/ILiquidityPool.sol
@@ -1,0 +1,7 @@
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ILiquidityPool {
+    function depositToRecipient(uint256 _amount) external returns (uint256);
+}


### PR DESCRIPTION
- Potential solution of how we could subsidization the losses from native minting with all eETH holders instead of collecting a fee.
- Requires a `depositToSyncPool` function to be added to the `liquidityPool` to allow unbacked deposits from the `syncPool`
- The protocol losses originate from `actualAmountOut < amountOut`; this added logic minting an unbacked amount of `weETH` to cover the losses