### PR TITLE
Adapter Migration Issue 5, 6, 8

### DIFF
--- a/utils/Constants.sol
+++ b/utils/Constants.sol
@@ -106,6 +106,9 @@ contract Constants {
     address constant L1_NETHERMIND_DVN = 0xa59BA433ac34D2927232918Ef5B2eaAfcF130BA5;
     address[2] L1_DVN = [0x589dEDbD617e0CBcB916A9223F4d1300c294236b, 0xa59BA433ac34D2927232918Ef5B2eaAfcF130BA5];
 
+    // https://docs.layerzero.network/v2/developers/solana/configuration/oapp-config#dead-dvn
+    address constant DEAD_DVN = 0x000000000000000000000000000000000000dEaD;
+
 
     address constant L1_SYNC_POOL_PROXY_ADMIN = 0xDBf6bE120D4dc72f01534673a1223182D9F6261D;
 

--- a/utils/LayerZeroHelpers.sol
+++ b/utils/LayerZeroHelpers.sol
@@ -48,4 +48,22 @@ contract LayerZeroHelpers {
         return abi.encode(ulnConfig);
     }
 
+    // get a dead ULN (unreachable path)
+    function _getDeadUln() public pure returns (bytes memory) {
+        address[] memory requiredDVNs = new address[](1);
+        requiredDVNs[0] = 0x000000000000000000000000000000000000dEaD;
+        
+
+        UlnConfig memory ulnConfig = UlnConfig({
+            confirmations: 64,
+            requiredDVNCount: 1,
+            optionalDVNCount: 0,
+            optionalDVNThreshold: 0,
+            requiredDVNs: requiredDVNs,
+            optionalDVNs: new address[](0)
+        });
+
+        return abi.encode(ulnConfig);
+    }
+
 }


### PR DESCRIPTION
- [5]: Setting the receive lib to the dead DVN to cause all messages set through this pathway to be blocked
  https://docs.layerzero.network/v2/developers/solana/configuration/oapp-config#dead-dvn

- [6]: Set the delegate to the ether.fi gnosis

- [8]: Setting the receive lib to the dead DVN to cause all messages set through this pathway to be blocked