### PR TITLE
`ContractCodeChecker` and updated OFT Verifier

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ fs_permissions = [{ access = "read-write", path = "./"}]
 optimizer = true
 optimizer_runs = 200
 solc_version = "0.8.20"
+bytecode_hash = 'none'
 
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/scripts/ContractCodeChecker.s.sol
+++ b/scripts/ContractCodeChecker.s.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {console} from "forge-std/console.sol";
+import {console2} from "forge-std/console2.sol";
+
+
+contract ContractCodeChecker {
+
+    event ByteMismatchSegment(
+        uint256 startIndex,
+        uint256 endIndex,
+        bytes aSegment,
+        bytes bSegment
+    );
+
+    function compareBytes(bytes memory a, bytes memory b) internal returns (bool) {
+        if (a.length != b.length) {
+            // Length mismatch, emit one big segment for the difference if that’s desirable
+            // or just return false. For clarity, we can just return false here.
+            return false;
+        }
+
+        uint256 len = a.length;
+        uint256 start = 0;
+        bool inMismatch = false;
+        bool anyMismatch = false;
+
+        for (uint256 i = 0; i < len; i++) {
+            bool mismatch = (a[i] != b[i]);
+            if (mismatch && !inMismatch) {
+                // Starting a new mismatch segment
+                start = i;
+                inMismatch = true;
+            } else if (!mismatch && inMismatch) {
+                // Ending the current mismatch segment at i-1
+                emitMismatchSegment(a, b, start, i - 1);
+                inMismatch = false;
+                anyMismatch = true;
+            }
+        }
+
+        // If we ended with a mismatch still open, close it out
+        if (inMismatch) {
+            emitMismatchSegment(a, b, start, len - 1);
+            anyMismatch = true;
+        }
+
+        // If no mismatch segments were found, everything matched
+        return !anyMismatch;
+    }
+
+    function emitMismatchSegment(
+        bytes memory a,
+        bytes memory b,
+        uint256 start,
+        uint256 end
+    ) internal {
+        // endIndex is inclusive
+        uint256 segmentLength = end - start + 1;
+
+        bytes memory aSegment = new bytes(segmentLength);
+        bytes memory bSegment = new bytes(segmentLength);
+
+        for (uint256 i = 0; i < segmentLength; i++) {
+            aSegment[i] = a[start + i];
+            bSegment[i] = b[start + i];
+        }
+
+        string memory aHex = bytesToHexString(aSegment);
+        string memory bHex = bytesToHexString(bSegment);
+
+        console2.log("- Mismatch segment at index [%s, %s]", start, end);
+        console2.logString(string.concat(" - ", aHex));
+        console2.logString(string.concat(" - ", bHex));
+
+        emit ByteMismatchSegment(start, end, aSegment, bSegment);
+    }
+
+    function bytesToHexString(bytes memory data) internal pure returns (string memory) {
+        bytes memory alphabet = "0123456789abcdef";
+
+        // Every byte corresponds to two hex characters
+        bytes memory str = new bytes(2 + data.length * 2);
+        str[0] = '0';
+        str[1] = 'x';
+        for (uint256 i = 0; i < data.length; i++) {
+            str[2 + i * 2] = alphabet[uint8(data[i] >> 4)];
+            str[3 + i * 2] = alphabet[uint8(data[i] & 0x0f)];
+        }
+        return string(str);
+    }
+
+    // Compare the full bytecode of two deployed contracts, ensuring a perfect match.
+    function verifyFullMatch(address deployedImpl, address localDeployed) public {
+        console2.log("Verifying full bytecode match...");
+        bytes memory localBytecode = address(localDeployed).code;
+        bytes memory onchainRuntimeBytecode = address(deployedImpl).code;
+
+        if (compareBytes(localBytecode, onchainRuntimeBytecode)) {
+            console2.log("-> Full Bytecode Match: Success\n");
+        } else {
+            console2.log("-> Full Bytecode Match: Fail\n");
+        }
+    }
+
+    function verifyPartialMatch(address deployedImpl, address localDeployed) public {
+        console2.log("Verifying partial bytecode match...");
+
+        // Fetch runtime bytecode from on-chain addresses
+        bytes memory localBytecode = localDeployed.code;
+        bytes memory onchainRuntimeBytecode = deployedImpl.code;
+        
+        // Optionally check length first (not strictly necessary if doing a partial match)
+        if (localBytecode.length == 0 || onchainRuntimeBytecode.length == 0) {
+            revert("One of the bytecode arrays is empty, cannot verify.");
+        }
+
+        // Attempt to trim metadata from both local and on-chain bytecode
+        bytes memory trimmedLocal = trimMetadata(localBytecode);
+        bytes memory trimmedOnchain = trimMetadata(onchainRuntimeBytecode);
+
+        // If trimmed lengths differ significantly, it suggests structural differences in code
+        if (trimmedLocal.length != trimmedOnchain.length) {
+            revert("Post-trim length mismatch: potential code differences.");
+        }
+
+        // Compare trimmed arrays byte-by-byte
+        if (compareBytes(trimmedLocal, trimmedOnchain)) {
+            console2.log("-> Partial Bytecode Match: Success\n");
+        } else {
+            console2.log("-> Partial Bytecode Match: Fail\n");
+        }
+    }
+
+    function verifyLengthMatch(address deployedImpl, address localDeployed) public {
+        console2.log("Verifying length match...");
+        bytes memory localBytecode = localDeployed.code;
+        bytes memory onchainRuntimeBytecode = deployedImpl.code;
+
+        if (localBytecode.length == onchainRuntimeBytecode.length) {
+            console2.log("-> Length Match: Success\n");
+        } else {
+            console2.log("-> Length Match: Fail\n");
+        }
+    }
+
+    function verifyContractByteCodeMatch(address deployedImpl, address localDeployed) public {
+        verifyLengthMatch(deployedImpl, localDeployed);
+        verifyPartialMatch(deployedImpl, localDeployed);
+        verifyFullMatch(deployedImpl, localDeployed);
+    }
+
+    // A helper function to remove metadata (CBOR encoded) from the end of the bytecode.
+    // This is a heuristic based on known patterns in the metadata.
+    function trimMetadata(bytes memory code) internal pure returns (bytes memory) {
+        // Metadata usually starts with 0xa2 or a similar tag near the end.
+        // We can scan backward for a known marker. 
+        // In Solidity 0.8.x, metadata often starts near the end with 0xa2 0x64 ... pattern.
+        // This is a simplified approach and may need refinement.
+        
+        // For a more robust approach, you'd analyze the last bytes. 
+        // Typically, the CBOR metadata is at the very end of the bytecode.
+        uint256 length = code.length;
+        if (length < 4) {
+            // Bytecode too short to have metadata
+            return code;
+        }
+
+        // Scan backward for a CBOR header (0xa2).
+        // We'll just look for 0xa2 from the end and truncate there.
+        for (uint256 i = length - 1; i > 0; i--) {
+            if (code[i] == 0xa2) {
+                console2.log("Found metadata start at index: ", i);
+                // print 8 bytes from this point
+                bytes memory tmp = new bytes(8);
+                for (uint256 j = 0; j < 8; j++) {
+                    tmp[j] = code[i + j];
+                }
+
+                // Found a possible metadata start. We'll cut just before 0xa2.
+                bytes memory trimmed = new bytes(i);
+                for (uint256 j = 0; j < i; j++) {
+                    trimmed[j] = code[j];
+                }
+                return trimmed;
+            }
+        }
+
+        // If no metadata marker found, return as is.
+        return code;
+    }
+    
+}


### PR DESCRIPTION
# Context
Even with thorough code reviews, it’s not practical for reviewers to manually confirm that the deployed smart contract bytecode matches the intended source code. The current approach allowed reviewers to (1) only check if the deployed contract’s bytecode length matched the locally compiled code, which is insufficient OR (2) cannot provide reasonings why/when the match can fail

A proper bytecode verification is necessary. Even if the deployer is well-intentioned, there’s always a risk of a compromised environment resulting in malicious bytecode being deployed.


# Approach

The on-chain contract bytecode can differ from the locally compiled version due to various factors, including metadata (such as comments, file paths, and compiler-generated data) and immutable variables set at deployment:
- Length Match: Compares only the length of the bytecode. This is a quick but incomplete check.
- Partial Match: Trims the trailing metadata and compares only the essential runtime code. This approach is often sufficient in practice, as it ignores non-functional metadata differences.
- Full Match: Compares the entire bytecode, including metadata. This requires that metadata match exactly https://docs.soliditylang.org/en/latest/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode

The partial match is implemented by trimming of the metadata part. Refer to `verifyPartialMatch` function

# OFT Impl 

```
  #1. Verification of [OFT implementation] bytecode...
  Verifying length match...
  -> Length Match: Success

  Verifying partial bytecode match...
  Found metadata start at index:  17969
  Found metadata start at index:  17969
  -> Partial Bytecode Match: Success

  Verifying full bytecode match...
  - Mismatch segment at index [17979, 18010]
   - 0x343699d12f0dc2c4eccec3707a3539c4f15bafd4f552cd9dbde51cbba94fa9a4
   - 0x0b8ccc47c76306e1e0d878d87f86bcce09038d25cf271243d76acbfceae45608
  -> Full Bytecode Match: Fail
  ```
  
In the example above, the length and partial matches succeed, indicating the core logic is consistent. The full match fails due to differences only in metadata. 

# OFT Proxy

```
  #2. Verification of [OFT proxy] bytecode...
  Verifying length match...
  -> Length Match: Success

  Verifying partial bytecode match...
  Found metadata start at index:  1106
  Found metadata start at index:  1106
  - Mismatch segment at index [28, 47]
   - 0x3906d620c902f58cbdadc966928e335da93508e1
   - 0xe917fad11ca0d835d3c8d960906195a641320cd7
  -> Partial Bytecode Match: Fail

  Verifying full bytecode match...
  - Mismatch segment at index [28, 47]
   - 0x3906d620c902f58cbdadc966928e335da93508e1
   - 0xe917fad11ca0d835d3c8d960906195a641320cd7
  - Mismatch segment at index [1116, 1134]
   - 0x9586d4bb62264e0cad9f0c698b8cb2f9ce6f55
   - 0x750e1f271a1af9129df8843cdf91f3a7fa07ba
  - Mismatch segment at index [1136, 1147]
   - 0x5461c8db53e37626eeb8160b
   - 0xca3bdf9cd03fc1259be37a55
  -> Full Bytecode Match: Fail
```

Sadly, the partial match fails for the proxy contract. Let's see the below code execution logs (you can get putting -vvvv when running the script)

```
    ├─ [698430] → new TransparentUpgradeableProxy@0xf13D09eD3cbdD1C930d4de74808de1f33B6b3D4f
    │   ├─ emit Upgraded(implementation: 0x04E5c62b27092234CeC69ec56Dfa0b2c97F72Eb3)
    │   ├─ [147264] 0x04E5c62b27092234CeC69ec56Dfa0b2c97F72Eb3::initialize("Wrapped eETH", "weETH", 0x8D5AAc5d3d5cda4c404fA7ee31B0822B648Bb150) [delegatecall]
    │   │   ├─ [23959] 0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa::setDelegate(0x8D5AAc5d3d5cda4c404fA7ee31B0822B648Bb150)
    │   │   │   ├─ emit DelegateSet(sender: TransparentUpgradeableProxy: [0xf13D09eD3cbdD1C930d4de74808de1f33B6b3D4f], delegate: 0x8D5AAc5d3d5cda4c404fA7ee31B0822B648Bb150)
    │   │   │   └─ ← [Stop] 
    │   │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0x8D5AAc5d3d5cda4c404fA7ee31B0822B648Bb150)
    │   │   ├─ emit RoleGranted(role: 0x0000000000000000000000000000000000000000000000000000000000000000, account: 0x8D5AAc5d3d5cda4c404fA7ee31B0822B648Bb150, sender: verifyOFT: [0x9f7cF1d1F558E57ef88a59ac3D47214eF25B6A06])
    │   │   ├─ emit Initialized(version: 1)
    │   │   └─ ← [Stop] 
    │   ├─ [236809] → new ProxyAdmin@0x3906d620C902F58CbDAdC966928E335DA93508E1
    │   │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0x8D5AAc5d3d5cda4c404fA7ee31B0822B648Bb150)
    │   │   └─ ← [Return] 1063 bytes of code
    │   ├─ emit AdminChanged(previousAdmin: 0x0000000000000000000000000000000000000000, newAdmin: ProxyAdmin: [0x3906d620C902F58CbDAdC966928E335DA93508E1])
    │   └─ ← [Return] 1159 bytes of code
```

It turns out that the mismatched bytes correspond to the `ProxyAdmin` contract address inserted by the `TransparentProxy` constructor. This is expected and not indicative of malicious code. Aside from that address difference, the logic matches. Thus, the proxy contract remains safe

# Conclusion
- Partial match is usually sufficient for practical verification, as it ensures that the core logic matches while ignoring known expected differences such as metadata and certain injected addresses
- Full match is more stringent and may fail due to metadata or environment-dependent variables



# TODO
- Implement full match OR Use SC code verification tool such as https://sourcify.dev/
- Set up a dedicated, controlled environment (e.g., on AWS ECS) that fetches the repository, compiles the code with known settings, and deploys using a secure deployer wallet to further reduce discrepancies and enhance trust in the verification process