### PR TITLE
Increase gas amount for native minting sync

### DIFF
--- a/scripts/generateEnforcedOptions.s.sol
+++ b/scripts/generateEnforcedOptions.s.sol
@@ -1,0 +1,46 @@
+import "forge-std/Script.sol";
+import "../utils/L2Constants.sol";
+import "../utils/GnosisHelpers.sol";
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
+import "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/interfaces/IOAppOptionsType3.sol";
+import { OptionsBuilder } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/libs/OptionsBuilder.sol";
+
+contract generateEnforcedOptionsTransactions is Script, L2Constants, GnosisHelpers {
+    using OptionsBuilder for bytes;
+
+    function run() public {
+        EnforcedOptionParam[] memory enforcedOptions = getEnforcedOptions(L1_EID);
+        string memory setEnforcedOptionsData = iToHex(abi.encodeWithSignature("setEnforcedOptions((uint32,uint16,bytes)[])", enforcedOptions));
+
+        string memory beraJson = _getGnosisHeader(BERA.CHAIN_ID);
+        beraJson = string.concat(beraJson, _getGnosisTransaction(iToHex(abi.encodePacked(BERA.L2_OFT)), setEnforcedOptionsData, true));
+
+        vm.writeJson(beraJson, "./output/berachainEnforcedOptions.json");
+    }
+
+    function getEnforcedOptions(uint32 _eid) public pure returns (EnforcedOptionParam[] memory) {
+        EnforcedOptionParam[] memory enforcedOptions = new EnforcedOptionParam[](3);
+        enforcedOptions[0] = EnforcedOptionParam({
+            eid: _eid,
+            msgType: 0,
+            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(400_000, 0)
+        });
+        
+        enforcedOptions[1] = EnforcedOptionParam({
+            eid: _eid,
+            msgType: 1,
+            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(400_000, 0)
+        });
+        enforcedOptions[2] = EnforcedOptionParam({
+            eid: _eid,
+            msgType: 2,
+            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(400_000, 0)
+        });
+
+        return enforcedOptions; 
+    }
+
+}

--- a/scripts/native-minting-deployment/DeployConfigureL2.s.sol
+++ b/scripts/native-minting-deployment/DeployConfigureL2.s.sol
@@ -83,18 +83,18 @@ contract L2NativeMintingScript is Script, L2Constants, GnosisHelpers {
         enforcedOptions[0] = EnforcedOptionParam({
             eid: _eid,
             msgType: 0,
-            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0)
+            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(400_000, 0)
         });
         
         enforcedOptions[1] = EnforcedOptionParam({
             eid: _eid,
             msgType: 1,
-            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0)
+            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(400_000, 0)
         });
         enforcedOptions[2] = EnforcedOptionParam({
             eid: _eid,
             msgType: 2,
-            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0)
+            options: OptionsBuilder.newOptions().addExecutorLzReceiveOption(400_000, 0)
         });
 
         return enforcedOptions; 


### PR DESCRIPTION
- currently 200k gas is supplied but 400k is necessary
https://dashboard.tenderly.co/ether-fi/ether-fi/tx/0x64a27ceb0e9d77029b369b5cd4cca0443641d1ffe2f991b0613ae284a1bbb7f9/gas-usage
- update script for future deployments and create transaction to update existing bera deployment