### PR TITLE
OFT role improvements

### DIFF
--- a/contracts/EtherfiOFTUpgradeable.sol
+++ b/contracts/EtherfiOFTUpgradeable.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import {EnumerableRoles} from "lib/solady/src/auth/EnumerableRoles.sol";
+import {EnumerableRoles} from "solady/src/auth/EnumerableRoles.sol";
 
 import {OFTUpgradeable} from "@layerzerolabs/lz-evm-oapp-v2/contracts-upgradeable/oft/OFTUpgradeable.sol";
 import {IMintableERC20} from "../interfaces/IMintableERC20.sol";

--- a/contracts/EtherfiOFTUpgradeable.sol
+++ b/contracts/EtherfiOFTUpgradeable.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {EnumerableRoles} from "lib/solady/src/auth/EnumerableRoles.sol";
 
 import {OFTUpgradeable} from "@layerzerolabs/lz-evm-oapp-v2/contracts-upgradeable/oft/OFTUpgradeable.sol";
 import {IMintableERC20} from "../interfaces/IMintableERC20.sol";
@@ -13,10 +13,10 @@ import {PairwiseRateLimiter} from "./PairwiseRateLimiter.sol";
  * @title Etherfi mintable upgradeable OFT token
  * @dev Extends MintableOFTUpgradeable with pausing and rate limiting functionality
  */
-contract EtherfiOFTUpgradeable is OFTUpgradeable, AccessControlUpgradeable, PausableUpgradeable, PairwiseRateLimiter, IMintableERC20 {
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
-    bytes32 public constant UNPAUSER_ROLE = keccak256("UNPAUSER_ROLE");
+contract EtherfiOFTUpgradeable is OFTUpgradeable, EnumerableRoles, PausableUpgradeable, PairwiseRateLimiter, IMintableERC20 {
+    uint256 public constant MINTER_ROLE = 1;
+    uint256 public constant PAUSER_ROLE = 2;
+    uint256 public constant UNPAUSER_ROLE = 3;
 
     /**
      * @dev Constructor for MintableOFT
@@ -35,8 +35,6 @@ contract EtherfiOFTUpgradeable is OFTUpgradeable, AccessControlUpgradeable, Paus
     function initialize(string memory name, string memory symbol, address owner) external virtual initializer {
         __OFT_init(name, symbol, owner);
         __Ownable_init(owner);
-
-        _grantRole(DEFAULT_ADMIN_ROLE, owner);
     }
 
     function _debit(
@@ -85,17 +83,12 @@ contract EtherfiOFTUpgradeable is OFTUpgradeable, AccessControlUpgradeable, Paus
     }
 
     /**
-     * @dev Overrides the role admin logic from AccessControlUpgradeable to restrict granting roles to the owner
+     * @dev Sets the status of `role` of `holder` to `active`.
+     * Only the owner can set roles.
      */
-    function grantRole(bytes32 role, address account) public override onlyOwner() {
-        _grantRole(role, account);
-    }
-
-    /**
-     * @dev Overrides the role admin logic from AccessControlUpgradeable to restrict revoking roles to the owner
-     */
-    function revokeRole(bytes32 role, address account) public override onlyOwner() {
-        _revokeRole(role, account);
+    function setRole(address holder, uint256 role, bool active) public payable override {
+        if (msg.sender != owner()) revert EnumerableRolesUnauthorized();
+        super._setRole(holder, role, active);
     }
 
     function updateTokenSymbol(string memory name_, string memory symbol_) external onlyOwner() {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
       "@layerzerolabs/lz-evm-oapp-v2": "^2.1.18",
       "@layerzerolabs/lz-evm-protocol-v2": "^2.1.27",
       "solidity-bytes-utils": "^0.8.2",
+      "solady": "github:Vectorized/solady",
       "layerzero-v2": "github:JorgeAtPaladin/LayerZero-v2#21ad027cf323c323619566d2c9d1f2fa404f021f"
     },
     "resolutions": {

--- a/test/EtherfiOFTUpgradeableRoles.t.sol
+++ b/test/EtherfiOFTUpgradeableRoles.t.sol
@@ -7,13 +7,13 @@ import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {EtherfiOFTUpgradeable} from "../contracts/EtherfiOFTUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import {EnumerableRoles} from "lib/solady/src/auth/EnumerableRoles.sol";
-import {EndpointV2Mock} from "lib/devtools/packages/test-devtools-evm-foundry/contracts/mocks/EndpointV2Mock.sol";
+import {EnumerableRoles} from "solady/src/auth/EnumerableRoles.sol";
+import {SimpleEndpointMock} from "./mock/SimpleEndpointMock.sol";
 
 contract EtherfiOFTUpgradeableRolesTest is Test {
 
     EtherfiOFTUpgradeable public etherfiOFT;
-    EndpointV2Mock public lzEndpoint;
+    SimpleEndpointMock public lzEndpoint;
 
     address public owner = makeAddr("owner");
     address public minter = makeAddr("minter");
@@ -23,7 +23,7 @@ contract EtherfiOFTUpgradeableRolesTest is Test {
     address public user2 = makeAddr("user2");
 
     function setUp() public {
-        lzEndpoint = new EndpointV2Mock(1, address(this));
+        lzEndpoint = new SimpleEndpointMock(1);
 
         EtherfiOFTUpgradeable etherfiOFTImpl = new EtherfiOFTUpgradeable(address(lzEndpoint));
         etherfiOFT = EtherfiOFTUpgradeable(address(new ERC1967Proxy(

--- a/test/EtherfiOFTUpgradeableRoles.t.sol
+++ b/test/EtherfiOFTUpgradeableRoles.t.sol
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {EtherfiOFTUpgradeable} from "../contracts/EtherfiOFTUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {EnumerableRoles} from "lib/solady/src/auth/EnumerableRoles.sol";
+import {EndpointV2Mock} from "lib/devtools/packages/test-devtools-evm-foundry/contracts/mocks/EndpointV2Mock.sol";
+
+contract EtherfiOFTUpgradeableRolesTest is Test {
+
+    EtherfiOFTUpgradeable public etherfiOFT;
+    EndpointV2Mock public lzEndpoint;
+
+    address public owner = makeAddr("owner");
+    address public minter = makeAddr("minter");
+    address public pauser = makeAddr("pauser");
+    address public unpauser = makeAddr("unpauser");
+    address public user = makeAddr("user");
+    address public user2 = makeAddr("user2");
+
+    function setUp() public {
+        lzEndpoint = new EndpointV2Mock(1, address(this));
+
+        EtherfiOFTUpgradeable etherfiOFTImpl = new EtherfiOFTUpgradeable(address(lzEndpoint));
+        etherfiOFT = EtherfiOFTUpgradeable(address(new ERC1967Proxy(
+            address(etherfiOFTImpl),
+            abi.encodeWithSelector(EtherfiOFTUpgradeable.initialize.selector, "EtherFi Token", "weETH", owner)
+        )));
+
+        vm.deal(user, 10 ether);
+        vm.deal(user2, 10 ether);
+    }
+
+    function test_RoleManagement() public {
+        address[] memory initialMinters = etherfiOFT.roleHolders(etherfiOFT.MINTER_ROLE());
+        address[] memory initialPausers = etherfiOFT.roleHolders(etherfiOFT.PAUSER_ROLE());
+        address[] memory initialUnpausers = etherfiOFT.roleHolders(etherfiOFT.UNPAUSER_ROLE());
+
+        assertEq(initialMinters.length, 0);
+        assertEq(initialPausers.length, 0);
+        assertEq(initialUnpausers.length, 0);
+
+        assertFalse(etherfiOFT.hasRole(minter, etherfiOFT.MINTER_ROLE()));
+        assertFalse(etherfiOFT.hasRole(pauser, etherfiOFT.PAUSER_ROLE()));
+        assertFalse(etherfiOFT.hasRole(unpauser, etherfiOFT.UNPAUSER_ROLE()));
+
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), true);
+        etherfiOFT.setRole(pauser, etherfiOFT.PAUSER_ROLE(), true);
+        etherfiOFT.setRole(unpauser, etherfiOFT.UNPAUSER_ROLE(), true);
+        vm.stopPrank();
+
+        assertTrue(etherfiOFT.hasRole(minter, etherfiOFT.MINTER_ROLE()));
+        assertTrue(etherfiOFT.hasRole(pauser, etherfiOFT.PAUSER_ROLE()));
+        assertTrue(etherfiOFT.hasRole(unpauser, etherfiOFT.UNPAUSER_ROLE()));
+
+        address[] memory minters = etherfiOFT.roleHolders(etherfiOFT.MINTER_ROLE());
+        address[] memory pausers = etherfiOFT.roleHolders(etherfiOFT.PAUSER_ROLE());
+        address[] memory unpausers = etherfiOFT.roleHolders(etherfiOFT.UNPAUSER_ROLE());
+
+        assertEq(minters.length, 1);
+        assertEq(pausers.length, 1);
+        assertEq(unpausers.length, 1);
+        assertEq(minters[0], minter);
+        assertEq(pausers[0], pauser);
+        assertEq(unpausers[0], unpauser);
+    }
+
+    function test_RoleManagement_OnlyOwner() public {
+        // Test that non-owner cannot set roles
+        vm.expectRevert(abi.encodeWithSelector(EnumerableRoles.EnumerableRolesUnauthorized.selector));
+        vm.prank(user);
+        etherfiOFT.setRole(minter, 1, true);
+
+        // Test that owner can set roles
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, 1, true);
+        vm.stopPrank();
+        assertTrue(etherfiOFT.hasRole(minter, 1));
+
+        vm.startPrank(owner);
+        etherfiOFT.setRole(user, 1, true);
+        vm.stopPrank();
+        assertTrue(etherfiOFT.hasRole(user, 1));
+    }
+
+    function test_Mint_WithoutRole() public {
+        vm.expectRevert(abi.encodeWithSelector(EnumerableRoles.EnumerableRolesUnauthorized.selector));
+        etherfiOFT.mint(user, 1000 ether);
+    }
+
+    function test_Mint_WithRole() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), true);
+        vm.stopPrank();
+
+        uint256 balanceBefore = etherfiOFT.balanceOf(user);
+        
+        vm.prank(minter);
+        etherfiOFT.mint(user, 1000 ether);
+
+        assertEq(etherfiOFT.balanceOf(user), balanceBefore + 1000 ether);
+    }
+
+    function test_PauseBridge_WithoutRole() public {
+        assertFalse(etherfiOFT.paused());
+
+        vm.expectRevert(abi.encodeWithSelector(EnumerableRoles.EnumerableRolesUnauthorized.selector));
+        etherfiOFT.pauseBridge();
+
+        assertFalse(etherfiOFT.paused());
+    }
+
+    function test_PauseBridge_WithRole() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(pauser, etherfiOFT.PAUSER_ROLE(), true);
+        vm.stopPrank();
+
+        assertFalse(etherfiOFT.paused());
+
+        vm.prank(pauser);
+        etherfiOFT.pauseBridge();
+
+        assertTrue(etherfiOFT.paused());
+    }
+
+    function test_UnpauseBridge_WithoutRole() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(pauser, etherfiOFT.PAUSER_ROLE(), true);
+        vm.stopPrank();
+
+        vm.prank(pauser);
+        etherfiOFT.pauseBridge();
+        assertTrue(etherfiOFT.paused());
+
+        vm.expectRevert(abi.encodeWithSelector(EnumerableRoles.EnumerableRolesUnauthorized.selector));
+        etherfiOFT.unpauseBridge();
+
+        assertTrue(etherfiOFT.paused());
+    }
+
+    function test_UnpauseBridge_WithRole() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(pauser, etherfiOFT.PAUSER_ROLE(), true);
+        etherfiOFT.setRole(unpauser, etherfiOFT.UNPAUSER_ROLE(), true);
+        vm.stopPrank();
+
+        vm.prank(pauser);
+        etherfiOFT.pauseBridge();
+        assertTrue(etherfiOFT.paused());
+
+        vm.prank(unpauser);
+        etherfiOFT.unpauseBridge();
+
+        assertFalse(etherfiOFT.paused());
+    }
+
+    function test_RoleRevocation() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), true);
+        vm.stopPrank();
+
+        assertTrue(etherfiOFT.hasRole(minter, etherfiOFT.MINTER_ROLE()));
+
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), false);
+        vm.stopPrank();
+
+        assertFalse(etherfiOFT.hasRole(minter, etherfiOFT.MINTER_ROLE()));
+
+        address[] memory minters = etherfiOFT.roleHolders(etherfiOFT.MINTER_ROLE());
+        assertEq(minters.length, 0);
+    }
+
+    function test_MultipleRoleHolders() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), true);
+        etherfiOFT.setRole(user, etherfiOFT.MINTER_ROLE(), true);
+        etherfiOFT.setRole(pauser, etherfiOFT.PAUSER_ROLE(), true);
+        etherfiOFT.setRole(user2, etherfiOFT.PAUSER_ROLE(), true);
+        etherfiOFT.setRole(unpauser, etherfiOFT.UNPAUSER_ROLE(), true);
+        vm.stopPrank();
+
+        address[] memory minters = etherfiOFT.roleHolders(etherfiOFT.MINTER_ROLE());
+        address[] memory pausers = etherfiOFT.roleHolders(etherfiOFT.PAUSER_ROLE());
+        address[] memory unpausers = etherfiOFT.roleHolders(etherfiOFT.UNPAUSER_ROLE());
+
+        assertEq(minters.length, 2);
+        assertEq(pausers.length, 2);
+        assertEq(unpausers.length, 1);
+
+        // Test that both minters can mint
+        vm.prank(minter);
+        etherfiOFT.mint(user, 1000 ether);
+        assertEq(etherfiOFT.balanceOf(user), 1000 ether);
+
+        vm.prank(user);
+        etherfiOFT.mint(user2, 500 ether);
+        assertEq(etherfiOFT.balanceOf(user2), 500 ether);
+
+        // Test that both pausers can pause
+        vm.prank(pauser);
+        etherfiOFT.pauseBridge();
+        assertTrue(etherfiOFT.paused());
+
+        vm.prank(unpauser);
+        etherfiOFT.unpauseBridge();
+        assertFalse(etherfiOFT.paused());
+
+        vm.prank(user2);
+        etherfiOFT.pauseBridge();
+        assertTrue(etherfiOFT.paused());
+    }
+
+    function test_RoleHolderCount() public {
+        assertEq(etherfiOFT.roleHolderCount(etherfiOFT.MINTER_ROLE()), 0);
+        assertEq(etherfiOFT.roleHolderCount(etherfiOFT.PAUSER_ROLE()), 0);
+        assertEq(etherfiOFT.roleHolderCount(etherfiOFT.UNPAUSER_ROLE()), 0);
+
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), true);
+        etherfiOFT.setRole(user, etherfiOFT.MINTER_ROLE(), true);
+        etherfiOFT.setRole(pauser, etherfiOFT.PAUSER_ROLE(), true);
+        vm.stopPrank();
+
+        assertEq(etherfiOFT.roleHolderCount(etherfiOFT.MINTER_ROLE()), 2);
+        assertEq(etherfiOFT.roleHolderCount(etherfiOFT.PAUSER_ROLE()), 1);
+        assertEq(etherfiOFT.roleHolderCount(etherfiOFT.UNPAUSER_ROLE()), 0);
+    }
+
+    function test_RoleHolderAt() public {
+        vm.startPrank(owner);
+        etherfiOFT.setRole(minter, etherfiOFT.MINTER_ROLE(), true);
+        etherfiOFT.setRole(user, etherfiOFT.MINTER_ROLE(), true);
+        vm.stopPrank();
+
+        address firstMinter = etherfiOFT.roleHolderAt(etherfiOFT.MINTER_ROLE(), 0);
+        address secondMinter = etherfiOFT.roleHolderAt(etherfiOFT.MINTER_ROLE(), 1);
+
+        // The order might vary, but both addresses should be present
+        assertTrue(firstMinter == minter || firstMinter == user);
+        assertTrue(secondMinter == minter || secondMinter == user);
+        assertTrue(firstMinter != secondMinter);
+
+        // Test out of bounds
+        vm.expectRevert(abi.encodeWithSelector(EnumerableRoles.RoleHoldersIndexOutOfBounds.selector));
+        etherfiOFT.roleHolderAt(1, 2);
+    }
+
+    function test_ZeroAddressRoleHolder() public {
+        vm.startPrank(owner);
+        vm.expectRevert(abi.encodeWithSelector(EnumerableRoles.RoleHolderIsZeroAddress.selector));
+        etherfiOFT.setRole(address(0), 1, true);
+        vm.stopPrank();
+    }
+}

--- a/test/mock/SimpleEndpointMock.sol
+++ b/test/mock/SimpleEndpointMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title SimpleEndpointMock
+ * @dev A minimal mock endpoint for testing purposes
+ * Only implements the functions needed for EtherfiOFTUpgradeable initialization
+ */
+contract SimpleEndpointMock {
+    uint32 public immutable eid;
+    
+    constructor(uint32 _eid) {
+        eid = _eid;
+    }
+    
+    // Allow delegate setting for initialization
+    function setDelegate(address) external {
+        // Mock implementation - does nothing
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,10 @@ forge-std@^1.1.2:
   version "2.0.2"
   resolved "https://codeload.github.com/JorgeAtPaladin/LayerZero-v2/tar.gz/21ad027cf323c323619566d2c9d1f2fa404f021f"
 
+"solady@github:Vectorized/solady":
+  version "0.1.26"
+  resolved "https://codeload.github.com/Vectorized/solady/tar.gz/208e4f31cfae26e4983eb95c3488a14fdc497ad7"
+
 solidity-bytes-utils@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/solidity-bytes-utils/-/solidity-bytes-utils-0.8.2.tgz#763d6a02fd093e93b3a97b742e97d540e66c29bd"


### PR DESCRIPTION
Changes our future OFT deployments to use solady enumerable roles for easy visibility into what addresses currently hold a given role. Also allows us to remove the redundant `DEFAULT_ADMIN_ROLE` role. 

note: this contract is not intended to be used to upgrade our current contracts. It will be utilized in future deployments