### PR TITLE
Move native-minting upgrade authority to the upgrade timelock (ETH/OP)

### DIFF
--- a/NATIVE-MINTING-UPGRADE-TIMELOCK.md
+++ b/NATIVE-MINTING-UPGRADE-TIMELOCK.md
@@ -1,0 +1,47 @@
+# Native minting: move upgrade authority to the upgrade timelock
+
+Today the native-minting proxies are upgradeable by the chain's **controller
+Safe directly, with no timelock delay**. This change moves that upgrade
+authority to the upgrade timelock so an implementation swap inherits the same
+delay as the rest of governance.
+
+Scope: Ethereum and Optimism (the chains requested).
+
+## What moves
+
+| Chain | Contract | ProxyAdmin | New owner (upgrade timelock) |
+|-------|----------|------------|------------------------------|
+| Ethereum | L1 sync pool (`0xD78987…`) | `0xDBf6bE12…` | `0x9f26d4…` (10-day) |
+| Optimism | L2 sync pool (`0xC9475e…`) | `0xecA0b8…` | `0x851Dd5…` (canonical L2) |
+| Optimism | exchange-rate provider (`0xAaE0d7…`) | `0x5ab0DC…` | `0x851Dd5…` |
+| Optimism | rate limiter (`0x9685Ff…`) | `0xc706AC…` | `0x851Dd5…` |
+
+Each transaction is `ProxyAdmin.transferOwnership(<timelock>)`, executed by the
+chain's controller Safe.
+
+On Ethereum the L1 **receiver** and **dummy-token** proxy admins are already
+owned by `0x9f26d4…`, so only the shared L1 sync pool admin needs to move.
+
+## Transactions (ready for 3CP)
+
+- `output/ethereum-NativeMinting-ProxyAdmin-ToTimelock.json` — L1 controller Safe `0x2aCA71…`, 1 tx.
+- `output/optimism-NativeMinting-ProxyAdmin-ToTimelock.json` — OP controller Safe `0x764682…`, 3 txs.
+
+## Verification
+
+`test/NativeMintingUpgradeTimelock.t.sol` forks Ethereum and Optimism, executes
+each transfer as the Safe, and asserts (a) the ProxyAdmin owner becomes the
+timelock and (b) the Safe can no longer upgrade. `test/L1SyncPoolUpgrade.t.sol`
+further proves the L1 sync pool can still be upgraded *through* the timelock
+(schedule → wait `minDelay` → execute) after the move.
+
+```bash
+forge test --match-path test/NativeMintingUpgradeTimelock.t.sol -vv
+forge test --match-path test/L1SyncPoolUpgrade.t.sol -vv
+```
+
+## Note
+
+Any upgrade pushed from this repo would ship current-repo logic; the deployed
+L1 sync pool implementation is not byte-reproducible from current source
+(compiler/source drift), so reconcile that before the first real upgrade.

--- a/output/ethereum-NativeMinting-ProxyAdmin-ToTimelock.json
+++ b/output/ethereum-NativeMinting-ProxyAdmin-ToTimelock.json
@@ -1,0 +1,14 @@
+{
+  "chainId": "1",
+  "safeAddress": "0x2aca71020de61bb532008049e1bd41e451ae8adc",
+  "meta": {
+    "txBuilderVersion": "1.16.5"
+  },
+  "transactions": [
+    {
+      "to": "0xdbf6be120d4dc72f01534673a1223182d9f6261d",
+      "value": "0",
+      "data": "0xf2fde38b0000000000000000000000009f26d4c958fd811a1f59b01b86be7dffc9d20761"
+    }
+  ]
+}

--- a/output/optimism-NativeMinting-ProxyAdmin-ToTimelock.json
+++ b/output/optimism-NativeMinting-ProxyAdmin-ToTimelock.json
@@ -1,0 +1,24 @@
+{
+  "chainId": "10",
+  "safeAddress": "0x764682c769ccb119349d92f1b63ee1c03d6aecff",
+  "meta": {
+    "txBuilderVersion": "1.16.5"
+  },
+  "transactions": [
+    {
+      "to": "0xeca0b8088bf30efd476f0a4e6b7e4b5d652b1ded",
+      "value": "0",
+      "data": "0xf2fde38b000000000000000000000000851dd540f4d2ec78120de0a0cc87b21ede5df5c6"
+    },
+    {
+      "to": "0x5ab0dce5dbef9c0284fbdb34a8f8e3cf5216ba2c",
+      "value": "0",
+      "data": "0xf2fde38b000000000000000000000000851dd540f4d2ec78120de0a0cc87b21ede5df5c6"
+    },
+    {
+      "to": "0xc706ac2f5c9332890a7dc37837675ed3dd116416",
+      "value": "0",
+      "data": "0xf2fde38b000000000000000000000000851dd540f4d2ec78120de0a0cc87b21ede5df5c6"
+    }
+  ]
+}

--- a/test/L1SyncPoolUpgrade.t.sol
+++ b/test/L1SyncPoolUpgrade.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../contracts/native-minting/EtherfiL1SyncPoolETH.sol";
+
+// Minimal OZ v5 ProxyAdmin surface (on-chain admin exposes upgradeAndCall, not upgrade).
+interface IProxyAdmin {
+    function owner() external view returns (address);
+    function transferOwnership(address newOwner) external;
+    function upgradeAndCall(address proxy, address impl, bytes calldata data) external payable;
+}
+
+// OZ TimelockController surface used to drive an upgrade once the admin is the timelock.
+interface ITimelock {
+    function getMinDelay() external view returns (uint256);
+    function schedule(address target, uint256 value, bytes calldata data, bytes32 predecessor, bytes32 salt, uint256 delay) external;
+    function execute(address target, uint256 value, bytes calldata payload, bytes32 predecessor, bytes32 salt) external payable;
+}
+
+// Fork test proving the L1 weETH sync pool upgrade path works end-to-end:
+// rebuild the current implementation, push it through the live ProxyAdmin (owned
+// by the L1 controller Safe), and assert storage + access control are intact.
+//
+// Run: forge test --match-path test/L1SyncPoolUpgrade.t.sol -vvv
+//   (override the fork RPC with L1_FORK_RPC=<url> if the default is rate-limited)
+contract L1SyncPoolUpgradeTest is Test {
+    address constant SYNC_POOL = 0xD789870beA40D056A4d26055d0bEFcC8755DA146;
+    address constant PROXY_ADMIN = 0xDBf6bE120D4dc72f01534673a1223182D9F6261D;
+    address constant LZ_ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
+    // The timelock that owns the sync pool today (owner()); 10-day delay.
+    address constant OWNER_TIMELOCK = 0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761;
+    // Governance Safe (6-of-10) holding PROPOSER + EXECUTOR on OWNER_TIMELOCK.
+    address constant GOV_GNOSIS = 0xcdd57D11476c22d265722F68390b036f3DA48c21;
+    // EIP-1967 implementation slot
+    bytes32 constant IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    IProxyAdmin proxyAdmin = IProxyAdmin(PROXY_ADMIN);
+    EtherfiL1SyncPoolETH pool = EtherfiL1SyncPoolETH(SYNC_POOL);
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("L1_FORK_RPC", string("https://ethereum-rpc.publicnode.com")));
+    }
+
+    function _impl() internal view returns (address) {
+        return address(uint160(uint256(vm.load(SYNC_POOL, IMPL_SLOT))));
+    }
+
+    function test_upgrade_preserves_state_and_access_control() public {
+        // snapshot pre-upgrade state
+        address oldImpl = _impl();
+        address admin = proxyAdmin.owner();
+        address owner_ = pool.owner();
+        address liquifier = pool.getLiquifier();
+        address eeth = pool.getEEth();
+        address tokenOut = pool.getTokenOut();
+        address lockBox = pool.getLockBox();
+        uint256 unbacked = pool.getTotalUnbackedTokens();
+
+        emit log_named_address("proxy admin owner (upgrade authority)", admin);
+        emit log_named_address("current implementation", oldImpl);
+
+        // rebuild the current implementation
+        EtherfiL1SyncPoolETH newImpl = new EtherfiL1SyncPoolETH(LZ_ENDPOINT);
+        assertTrue(address(newImpl) != oldImpl, "fresh impl collided with old");
+
+        // a non-owner must not be able to upgrade
+        vm.prank(address(0xBAD));
+        vm.expectRevert();
+        proxyAdmin.upgradeAndCall(SYNC_POOL, address(newImpl), "");
+        assertEq(_impl(), oldImpl, "impl changed on unauthorized call");
+
+        // the ProxyAdmin owner (L1 controller Safe) performs the upgrade
+        vm.prank(admin);
+        proxyAdmin.upgradeAndCall(SYNC_POOL, address(newImpl), "");
+
+        // implementation switched
+        assertEq(_impl(), address(newImpl), "impl slot not updated");
+
+        // storage preserved across the upgrade
+        assertEq(pool.owner(), owner_, "owner changed");
+        assertEq(pool.getLiquifier(), liquifier, "liquifier changed");
+        assertEq(pool.getEEth(), eeth, "eEth changed");
+        assertEq(pool.getTokenOut(), tokenOut, "tokenOut changed");
+        assertEq(pool.getLockBox(), lockBox, "lockBox changed");
+        assertEq(pool.getTotalUnbackedTokens(), unbacked, "unbacked tokens changed");
+    }
+
+    // Proves the requested change: move upgrade authority from the controller
+    // Safe to the owner timelock, then show the Safe can no longer upgrade while
+    // the timelock can (schedule -> wait minDelay -> execute), state preserved.
+    function test_transfer_admin_to_timelock_then_upgrade_via_timelock() public {
+        address safe = proxyAdmin.owner();
+        assertTrue(safe != OWNER_TIMELOCK, "admin already the timelock");
+
+        // 1. Safe transfers ProxyAdmin ownership to the timelock (the 3CP tx).
+        vm.prank(safe);
+        proxyAdmin.transferOwnership(OWNER_TIMELOCK);
+        assertEq(proxyAdmin.owner(), OWNER_TIMELOCK, "admin not moved to timelock");
+
+        // 2. The Safe can no longer upgrade.
+        EtherfiL1SyncPoolETH newImpl = new EtherfiL1SyncPoolETH(LZ_ENDPOINT);
+        vm.prank(safe);
+        vm.expectRevert();
+        proxyAdmin.upgradeAndCall(SYNC_POOL, address(newImpl), "");
+        assertTrue(_impl() != address(newImpl), "Safe upgrade should have reverted");
+
+        // 3. The timelock can upgrade, driven by the governance Safe.
+        address owner_ = pool.owner();
+        uint256 unbacked = pool.getTotalUnbackedTokens();
+        bytes memory up = abi.encodeWithSignature(
+            "upgradeAndCall(address,address,bytes)", SYNC_POOL, address(newImpl), bytes("")
+        );
+        uint256 delay = ITimelock(OWNER_TIMELOCK).getMinDelay();
+
+        vm.prank(GOV_GNOSIS);
+        ITimelock(OWNER_TIMELOCK).schedule(PROXY_ADMIN, 0, up, bytes32(0), bytes32(0), delay);
+        vm.warp(block.timestamp + delay + 1);
+        vm.prank(GOV_GNOSIS);
+        ITimelock(OWNER_TIMELOCK).execute(PROXY_ADMIN, 0, up, bytes32(0), bytes32(0));
+
+        assertEq(_impl(), address(newImpl), "timelock upgrade did not take effect");
+        assertEq(pool.owner(), owner_, "owner changed");
+        assertEq(pool.getTotalUnbackedTokens(), unbacked, "state changed");
+    }
+
+    // Diagnostic: characterize how the repo-rebuilt implementation differs from
+    // the deployed one. A tail-only difference is just CBOR metadata (benign);
+    // an earlier divergence means real source/compiler drift.
+    function test_diagnostic_rebuilt_vs_onchain_bytecode() public {
+        bytes memory onchain = _impl().code;
+        bytes memory rebuilt = address(new EtherfiL1SyncPoolETH(LZ_ENDPOINT)).code;
+        emit log_named_uint("on-chain impl code length", onchain.length);
+        emit log_named_uint("rebuilt  impl code length", rebuilt.length);
+
+        uint256 min = onchain.length < rebuilt.length ? onchain.length : rebuilt.length;
+        uint256 firstDiff = min;
+        for (uint256 i = 0; i < min; i++) {
+            if (onchain[i] != rebuilt[i]) {
+                firstDiff = i;
+                break;
+            }
+        }
+        emit log_named_uint("first differing byte offset", firstDiff);
+        emit log_named_uint("identical-prefix as % of shorter", min == 0 ? 0 : (firstDiff * 100) / min);
+        emit log_string(
+            firstDiff >= min
+                ? "prefixes identical up to min length -> difference is trailing metadata only (benign)"
+                : "divergence before the tail -> source/compiler settings differ from the deployed version"
+        );
+    }
+}

--- a/test/NativeMintingUpgradeTimelock.t.sol
+++ b/test/NativeMintingUpgradeTimelock.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+// OZ v5 ProxyAdmin surface (these admins expose upgradeAndCall + Ownable).
+interface IProxyAdmin {
+    function owner() external view returns (address);
+    function transferOwnership(address newOwner) external;
+    function upgradeAndCall(address proxy, address impl, bytes calldata data) external payable;
+}
+
+// Fork test for the native-minting upgrade-authority transfer on Ethereum and
+// Optimism: move each ProxyAdmin from the controller Safe to the upgrade
+// timelock, then prove the Safe can no longer upgrade. These are exactly the
+// transactions encoded in:
+//   output/ethereum-NativeMinting-ProxyAdmin-ToTimelock.json   (L1 controller Safe)
+//   output/optimism-NativeMinting-ProxyAdmin-ToTimelock.json   (OP controller Safe)
+//
+// Run:
+//   forge test --match-path test/NativeMintingUpgradeTimelock.t.sol -vv
+//   (override forks with L1_FORK_RPC / OP_FORK_RPC if the defaults are throttled)
+contract NativeMintingUpgradeTimelockTest is Test {
+    // --- Ethereum ---
+    address constant ETH_SAFE = 0x2aCA71020De61bb532008049e1Bd41E451aE8AdC; // L1 controller Safe
+    address constant ETH_TIMELOCK = 0x9f26d4C958fD811A1F59B01B86Be7dFFc9d20761; // L1 upgrade timelock
+    address constant L1_SYNCPOOL = 0xD789870beA40D056A4d26055d0bEFcC8755DA146;
+    address constant L1_SYNCPOOL_PA = 0xDBf6bE120D4dc72f01534673a1223182D9F6261D;
+
+    // --- Optimism ---
+    address constant OP_SAFE = 0x764682c769CcB119349d92f1B63ee1c03d6AECFf; // OP controller Safe
+    address constant OP_TIMELOCK = 0x851Dd540f4D2Ec78120De0a0cc87B21EdE5Df5C6; // canonical L2 timelock
+    address constant OP_SYNCPOOL = 0xC9475e18E2C5C26EA6ADCD55fabE07920beA887e;
+    address constant OP_SYNCPOOL_PA = 0xecA0b8088bF30eFd476F0a4e6b7e4B5D652b1ded;
+    address constant OP_EXCHRATE = 0xAaE0d7D8147C9f2C39A0B19974f8E684fA2bbA6f;
+    address constant OP_EXCHRATE_PA = 0x5ab0DCe5dbef9C0284fBdb34a8f8e3CF5216bA2c;
+    address constant OP_RATELIMITER = 0x9685Ff6E421F163A9A2FbB831F28344f8e4a964a;
+    address constant OP_RATELIMITER_PA = 0xc706AC2F5c9332890A7DC37837675ed3dd116416;
+
+    // Transfer a ProxyAdmin from `safe` to `timelock` and prove the move revoked
+    // the Safe's upgrade power.
+    function _transferAndVerify(address pa, address proxy, address safe, address timelock) internal {
+        assertEq(IProxyAdmin(pa).owner(), safe, "pre: admin owner is not the Safe");
+
+        vm.prank(safe);
+        IProxyAdmin(pa).transferOwnership(timelock);
+        assertEq(IProxyAdmin(pa).owner(), timelock, "post: admin owner is not the timelock");
+
+        // the Safe can no longer drive an upgrade (onlyOwner now reverts)
+        vm.prank(safe);
+        vm.expectRevert();
+        IProxyAdmin(pa).upgradeAndCall(proxy, address(0xdEaD), "");
+    }
+
+    function test_ethereum_native_minting_admin_to_timelock() public {
+        vm.createSelectFork(vm.envOr("L1_FORK_RPC", string("https://ethereum-rpc.publicnode.com")));
+        // L1 receiver + dummy-token admins are already timelock-owned; only the
+        // shared L1 sync pool admin still sits on the Safe.
+        _transferAndVerify(L1_SYNCPOOL_PA, L1_SYNCPOOL, ETH_SAFE, ETH_TIMELOCK);
+    }
+
+    function test_optimism_native_minting_admins_to_timelock() public {
+        vm.createSelectFork(vm.envOr("OP_FORK_RPC", string("https://optimism-rpc.publicnode.com")));
+        _transferAndVerify(OP_SYNCPOOL_PA, OP_SYNCPOOL, OP_SAFE, OP_TIMELOCK);
+        _transferAndVerify(OP_EXCHRATE_PA, OP_EXCHRATE, OP_SAFE, OP_TIMELOCK);
+        _transferAndVerify(OP_RATELIMITER_PA, OP_RATELIMITER, OP_SAFE, OP_TIMELOCK);
+    }
+}


### PR DESCRIPTION
## What

The native-minting proxies are upgradeable by each chain's controller Safe **directly, with no timelock delay**. This moves that upgrade authority to the upgrade timelock, so an implementation swap goes through the same delay as the rest of governance.

Scope: Ethereum and Optimism.

## Transfers

| Chain | Contract | ProxyAdmin | New owner |
|-------|----------|------------|-----------|
| Ethereum | L1 sync pool | `0xDBf6bE12…` | `0x9f26d4…` (10-day upgrade timelock) |
| Optimism | L2 sync pool | `0xecA0b8…` | `0x851Dd5…` (canonical L2 timelock) |
| Optimism | exchange-rate provider | `0x5ab0DC…` | `0x851Dd5…` |
| Optimism | rate limiter | `0xc706AC…` | `0x851Dd5…` |

Each tx is `ProxyAdmin.transferOwnership(<timelock>)`, executed by the chain's controller Safe. On Ethereum the L1 receiver and dummy-token admins are already timelock-owned, so only the shared L1 sync pool admin moves.

## Contents

- `output/ethereum-NativeMinting-ProxyAdmin-ToTimelock.json` — L1 Safe `0x2aCA71…`, 1 tx (for 3CP).
- `output/optimism-NativeMinting-ProxyAdmin-ToTimelock.json` — OP Safe `0x764682…`, 3 txs (for 3CP).
- `test/NativeMintingUpgradeTimelock.t.sol` — forks ETH + OP, executes each transfer as the Safe, asserts the admin owner becomes the timelock and the Safe can no longer upgrade.
- `test/L1SyncPoolUpgrade.t.sol` — proves the L1 sync pool can still be upgraded through the timelock (schedule → wait minDelay → execute) after the move.
- `NATIVE-MINTING-UPGRADE-TIMELOCK.md` — summary + verification steps.

## Verification

```
forge test --match-path test/NativeMintingUpgradeTimelock.t.sol -vv
forge test --match-path test/L1SyncPoolUpgrade.t.sol -vv
```

Both pass against live mainnet/Optimism state.

## Note

The deployed L1 sync pool implementation is not byte-reproducible from current source (compiler/source drift), so an upgrade from this repo would ship current-repo logic. Reconcile before the first real upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)